### PR TITLE
Use colors from the syntax theme

### DIFF
--- a/styles/diff.less
+++ b/styles/diff.less
@@ -6,27 +6,27 @@
 
 @images: "atom://diff/assets/images";
 
-.source.diff {
+atom-text-editor::shadow {
+  .source.diff {
+    span.meta.diff.header.from-file {
+      color: @text-color-success;
+    }
 
+    span.meta.diff.header.to-file {
+      color: @text-color-success;
+    }
 
-  span.meta.diff.header.from-file {
-    color: @text-color-success;
-  }
+    span.meta.diff.range.unified,
+    span.meta.diff.toc-list.line-number {
+      color: @text-color-warning;
+    }
 
-  span.meta.diff.header.to-file {
-    color: @text-color-success;
-  }
+    span.markup.deleted.diff {
+      color: #C6C5FE;
+    }
 
-  span.meta.diff.range.unified,
-  span.meta.diff.toc-list.line-number {
-    color: @text-color-warning;
-  }
-
-  span.markup.deleted.diff {
-    color: #C6C5FE;
-  }
-
-  span.markup.inserted.diff {
-    color: #96CBFE;
+    span.markup.inserted.diff {
+      color: #96CBFE;
+    }
   }
 }

--- a/styles/diff.less
+++ b/styles/diff.less
@@ -22,11 +22,15 @@ atom-text-editor::shadow {
     }
 
     span.markup.deleted.diff {
-      color: #C6C5FE;
+      &, span.punctuation.definition.diff {
+        color: #C6C5FE;
+      }
     }
 
     span.markup.inserted.diff {
-      color: #96CBFE;
+      &, span.punctuation.definition.diff {
+        color: #96CBFE;
+      }
     }
   }
 }

--- a/styles/diff.less
+++ b/styles/diff.less
@@ -23,13 +23,13 @@ atom-text-editor::shadow {
 
     span.markup.deleted.diff {
       &, span.punctuation.definition.diff {
-        color: #C6C5FE;
+        color: @syntax-color-removed;
       }
     }
 
     span.markup.inserted.diff {
       &, span.punctuation.definition.diff {
-        color: #96CBFE;
+        color: @syntax-color-added;
       }
     }
   }


### PR DESCRIPTION
The styling didn't work for me at all at the beginning, must have been the Atom update to shadow DOM? Anyway, fixed that.

Also, now the whole line is highlighted, including `+` and `-`. Assuming you agree that's better.